### PR TITLE
change npm version to the current published version to resolve publish error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwiktools/qwik-ui",
-  "version": "0.0.3-rc1",
+  "version": "0.0.3",
   "description": "Qwik component library",
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,1 @@
-export { Logo } from "./components/logo/logo";
-export { Counter } from "./components/counter/counter";
+export { Button } from './components/Button/button';


### PR DESCRIPTION
![Screenshot 2023-03-14 at 3 54 05 PM](https://user-images.githubusercontent.com/60404253/224971309-3b2d7169-7783-4d1c-a469-0a47e6cdab26.png)
Getting this error currently while trying to publish, I am the member of qwiktools on NPM. 
https://stackoverflow.com/questions/62830477/how-to-debug-npm-err-403-in-most-cases-you-or-one-of-your-dependencies-are-re
Its mentioned in this answer to try by changing the version in package.json
